### PR TITLE
Twemoji の取得先をtwemoji.maxcdn.com から cdn.jsdelivr.net  に切り替えた

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-brightgreen)](LICENSE)
 
 Convert emoji 🦕 to twemoji
-<img src="https://twemoji.maxcdn.com/v/13.1.0/72x72/1f995.png" alt="sauropod" style="height: 1em;width: 1em;margin: 0 0.05em 0 0.1em;vertical-align: -0.1em;">
+<img src="https://cdn.jsdelivr.net/gh/twitter/twemoji@13.1.0/assets/72x72/1f995.png" alt="sauropod" style="height: 1em;width: 1em;margin: 0 0.05em 0 0.1em;vertical-align: -0.1em;">
 by Deno
 <img src="https://icongr.am/simple/deno.svg" alt="deno" style="height: 1em;width: 1em;margin: 0 0.05em 0 0.1em;vertical-align: -0.1em;">
 

--- a/handlers.ts
+++ b/handlers.ts
@@ -35,7 +35,7 @@ export async function handleApi(
   console.log({ emoji, codePoint });
 
   const twemojiURL =
-    `https://twemoji.maxcdn.com/v/${VERSION}/72x72/${codePoint}.png`;
+    `https://cdn.jsdelivr.net/gh/twitter/twemoji@${VERSION}/assets/72x72/${codePoint}.png`;
 
   const res = await fetch(twemojiURL);
   // confirm to close resource

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta property="og:site_name" content="" />
     <meta
       property="og:image"
-      content="https://twemoji.maxcdn.com/v/13.1.0/72x72/1f995.png"
+      content="https://cdn.jsdelivr.net/gh/twitter/twemoji@13.1.0/assets/72x72/1f995.png"
     />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@kawarimidoll" />
@@ -25,7 +25,7 @@
     <link
       rel="icon"
       type="image/png"
-      href="https://twemoji.maxcdn.com/v/13.1.0/72x72/1f995.png"
+      href="https://cdn.jsdelivr.net/gh/twitter/twemoji@13.1.0/assets/72x72/1f995.png"
     />
     <style>
       body {
@@ -67,7 +67,7 @@
     <p>
       Convert emoji 🦕 to twemoji
       <img
-        src="https://twemoji.maxcdn.com/v/13.1.0/72x72/1f995.png"
+        src="https://cdn.jsdelivr.net/gh/twitter/twemoji@13.1.0/assets/72x72/1f995.png"
         alt="sauropod"
       />
       by Deno

--- a/test.ts
+++ b/test.ts
@@ -70,6 +70,9 @@ Deno.test("[handleApi] successful", async () => {
   params.set("emoji", "🦕");
   assertEquals(
     await handleApi(params),
-    ["https://twemoji.maxcdn.com/v/13.1.0/72x72/1f995.png", {}],
+    [
+      "https://cdn.jsdelivr.net/gh/twitter/twemoji@13.1.0/assets/72x72/1f995.png",
+      {},
+    ],
   );
 });


### PR DESCRIPTION
twemoji.maxcdn.com が今年のうちに終了するので cdn.jsdelivr.net から取得するようにしました


参考記事
https://zenn.dev/yhatt/articles/60ce0c3ca79994